### PR TITLE
feat: Add .nojekyll file, update mkdocs.yml, and include disclaimer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,21 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
 
+## Disclaimer
+
+**Please note that these packages for Filament are not officially operated by Filament and do not provide any support or warranty from the Filament team. The use of these packages is at your own risk.**
+
+This project represents unofficial extensions for Filament and is maintained by an independent community of developers. We strive to maintain compatibility with the current versions of Filament, but we cannot guarantee that the packages will function flawlessly or be compatible with future versions of Filament.
+
+We recommend users to create backups of their projects and thoroughly test them before using these packages. If you have any questions, issues, or suggestions, we are available to assist you. However, please note that we cannot provide official support for these packages.
+
+We would like to emphasize that Filament is a separate developer community independent of this project. For more information about Filament, please refer to the official Filament website.
+
+Please read the license terms to learn more about the conditions for using these packages.
+
 ---
+
+## Screenshots
 
 ![verbaende](./src/docs/assets/001_verbaende.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: filament-tournament-league-administration
+docs_dir: mkdocs
+site_dir: docs
 theme:
     font: false
     name: material


### PR DESCRIPTION
**Summary**
This pull request includes multiple changes to enhance the project documentation and provide necessary disclaimers.

**Changes Made**
- Created a `.nojekyll` file to prevent Jekyll processing on GitHub Pages, ensuring that the documentation is displayed correctly.
- Updated the `mkdocs.yml` file with the following lines:
  - `docs_dir: mkdocs`
  - `site_dir: docs`
- Added a disclaimer in the README file to clearly state that the provided packages are unofficial and not officially supported by Filament.

**Context**
The addition of the `.nojekyll` file and the configuration changes in `mkdocs.yml` are essential for proper documentation rendering and deployment on GitHub Pages. This ensures that the documentation is displayed as intended, and the file structure is organized correctly. Furthermore, the disclaimer in the README file helps to distinguish these packages as unofficial and independent of the official Filament project.