### PR TITLE
fix: logic extension for the scopeRecalculatePoints method within the Teams class

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -536,16 +536,16 @@
         },
         {
             "name": "filament/spatie-laravel-media-library-plugin",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
-                "reference": "1a44784b3424e0ea736fa37645ecc53db8a2fb39"
+                "reference": "024bc7154d27c8c1d07086fff1ace2e6a392e215"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-media-library-plugin/zipball/1a44784b3424e0ea736fa37645ecc53db8a2fb39",
-                "reference": "1a44784b3424e0ea736fa37645ecc53db8a2fb39",
+                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-media-library-plugin/zipball/024bc7154d27c8c1d07086fff1ace2e6a392e215",
+                "reference": "024bc7154d27c8c1d07086fff1ace2e6a392e215",
                 "shasum": ""
             },
             "require": {
@@ -569,7 +569,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2023-04-21T08:32:47+00:00"
+            "time": "2023-05-20T17:45:50+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -6835,16 +6835,16 @@
         },
         {
             "name": "filament/filament",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/app.git",
-                "reference": "d016e8e394f4658bf5e867aa71b70aab01f9a038"
+                "reference": "1e13fc1e8bfe2ff326531d3460f7725e5be5db2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/app/zipball/d016e8e394f4658bf5e867aa71b70aab01f9a038",
-                "reference": "d016e8e394f4658bf5e867aa71b70aab01f9a038",
+                "url": "https://api.github.com/repos/filamentphp/app/zipball/1e13fc1e8bfe2ff326531d3460f7725e5be5db2a",
+                "reference": "1e13fc1e8bfe2ff326531d3460f7725e5be5db2a",
                 "shasum": ""
             },
             "require": {
@@ -6894,20 +6894,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2023-05-17T16:33:26+00:00"
+            "time": "2023-05-20T17:46:01+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "63b484bdcf2c12baaaf6b39c66e6dd4c345fc65d"
+                "reference": "9ffadca5641227f00df2e6042cefbed1716ee00f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/63b484bdcf2c12baaaf6b39c66e6dd4c345fc65d",
-                "reference": "63b484bdcf2c12baaaf6b39c66e6dd4c345fc65d",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/9ffadca5641227f00df2e6042cefbed1716ee00f",
+                "reference": "9ffadca5641227f00df2e6042cefbed1716ee00f",
                 "shasum": ""
             },
             "require": {
@@ -6952,11 +6952,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2023-05-17T16:33:21+00:00"
+            "time": "2023-05-20T17:45:55+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
@@ -7009,7 +7009,7 @@
         },
         {
             "name": "filament/spatie-laravel-settings-plugin",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-settings-plugin.git",
@@ -7056,16 +7056,16 @@
         },
         {
             "name": "filament/spatie-laravel-tags-plugin",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-tags-plugin.git",
-                "reference": "a964dedc6405493992597e97127d942ff91437bc"
+                "reference": "70ed1268cdd3b631e90b8326c20882962674f57f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-tags-plugin/zipball/a964dedc6405493992597e97127d942ff91437bc",
-                "reference": "a964dedc6405493992597e97127d942ff91437bc",
+                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-tags-plugin/zipball/70ed1268cdd3b631e90b8326c20882962674f57f",
+                "reference": "70ed1268cdd3b631e90b8326c20882962674f57f",
                 "shasum": ""
             },
             "require": {
@@ -7089,11 +7089,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2023-01-25T18:16:12+00:00"
+            "time": "2023-05-20T17:45:48+00:00"
         },
         {
             "name": "filament/spatie-laravel-translatable-plugin",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-translatable-plugin.git",
@@ -7139,16 +7139,16 @@
         },
         {
             "name": "filament/support",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "79be557c4aa426eddb250421a9270724e32a683c"
+                "reference": "c8130bcb455e452f15eeb120958e8c26fba5fba1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/79be557c4aa426eddb250421a9270724e32a683c",
-                "reference": "79be557c4aa426eddb250421a9270724e32a683c",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/c8130bcb455e452f15eeb120958e8c26fba5fba1",
+                "reference": "c8130bcb455e452f15eeb120958e8c26fba5fba1",
                 "shasum": ""
             },
             "require": {
@@ -7185,20 +7185,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2023-05-17T16:33:21+00:00"
+            "time": "2023-05-20T17:45:49+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v2.17.41",
+            "version": "v2.17.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "62653b7e77c7d602ac6ca26075c399088c55be10"
+                "reference": "410d95d377769941499267ef2c8e4548238600e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/62653b7e77c7d602ac6ca26075c399088c55be10",
-                "reference": "62653b7e77c7d602ac6ca26075c399088c55be10",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/410d95d377769941499267ef2c8e4548238600e5",
+                "reference": "410d95d377769941499267ef2c8e4548238600e5",
                 "shasum": ""
             },
             "require": {
@@ -7241,7 +7241,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2023-05-17T16:33:20+00:00"
+            "time": "2023-05-20T17:45:54+00:00"
         },
         {
             "name": "filp/whoops",

--- a/src/Models/Game.php
+++ b/src/Models/Game.php
@@ -26,6 +26,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|Game activeMatches(GameSchedule $gameSchedule, Carbon $now)
  */
 class Game extends TranslateableModel
 {

--- a/src/Models/Game.php
+++ b/src/Models/Game.php
@@ -2,6 +2,7 @@
 
 namespace Maggomann\FilamentTournamentLeagueAdministration\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -89,5 +90,17 @@ class Game extends TranslateableModel
     public function scopeCollection(Builder $query, string $collectionName): Builder
     {
         return $query->where('collection_name', $collectionName);
+    }
+
+    public function scopeActiveMatches(Builder $query, GameSchedule $gameSchedule, ?Carbon $now = null): Builder
+    {
+        if (blank($now)) {
+            $now = now();
+        }
+
+        return $query
+            ->whereBelongsTo($gameSchedule)
+            ->where('ended_at', '<=', $now)
+            ->where(fn ($subQuery) => $subQuery->where('home_points_games', '>', 0)->orWhere('guest_points_games', '>', 0));
     }
 }

--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -132,57 +132,45 @@ class Team extends TranslateableModel implements HasMedia
         return $query
             ->where('id', $this->id)
             ->withSum([
-                'homeGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)
-                    ->where('ended_at', '<=', $now),
+                'homeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_legs')
             ->withSum([
-                'guestGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'guestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_legs')
             ->withSum([
-                'opponentHomeGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'opponentHomeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_legs')
             ->withSum([
-                'opponentGuestGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'opponentGuestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_legs')
             ->withSum([
-                'homeGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'homeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_games')
             ->withSum([
-                'guestGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'guestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_games')
             ->withSum([
-                'opponentGuestGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'opponentGuestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_games')
             ->withSum([
-                'opponentHomeGames' => fn (Builder $query) => $query->where('game_schedule_id', $gameSchedule->id)->where('ended_at', '<=', $now),
+                'opponentHomeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_games')
             ->withCount([
-                'games as total_number_of_encounters' => fn (Builder $query) => $query
-                    ->where('game_schedule_id', $gameSchedule->id)
-                    ->where('ended_at', '<=', $now),
-
-                'games as total_wins' => fn (Builder $query) => $query
-                    ->where('game_schedule_id', $gameSchedule->id)
-                    ->where('ended_at', '<=', $now)
+                'games as total_number_of_encounters' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'games as total_wins' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
                     ->where(fn ($subQuery) => $subQuery->where(fn ($subQuery) => $subQuery->where('home_team_id', $this->id)->whereRaw('home_points_games > guest_points_games')
                     )->orWhere(fn ($subQuery) => $subQuery->where('guest_team_id', $this->id)->whereRaw('home_points_games < guest_points_games')
                     )
                     ),
-                'games as total_defeats' => fn (Builder $query) => $query
-                    ->where('game_schedule_id', $gameSchedule->id)
-                    ->where('ended_at', '<=', $now)
+                'games as total_defeats' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
                     ->where(fn ($subQuery) => $subQuery->where(fn ($subQuery) => $subQuery->where('home_team_id', $this->id)->whereRaw('home_points_games < guest_points_games')
                     )->orWhere(fn ($subQuery) => $subQuery->where('guest_team_id', $this->id)->whereRaw('home_points_games > guest_points_games')
                     )
                     ),
-                'games as total_draws' => fn (Builder $query) => $query
-                    ->where('game_schedule_id', $gameSchedule->id)
-                    ->where('ended_at', '<=', $now)
+                'games as total_draws' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
                     ->whereRaw('home_points_games = guest_points_games'),
 
-                'games as total_victory_after_defeats' => fn (Builder $query) => $query
-                    ->where('game_schedule_id', $gameSchedule->id)
-                    ->where('ended_at', '<=', $now)
+                'games as total_victory_after_defeats' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
                     ->where(fn ($subQuery) => $subQuery->where(fn ($subQuery) => $subQuery->where('home_team_id', $this->id)->whereRaw('home_points_after_draw > guest_points_after_draw')
                     )->orWhere(fn ($subQuery) => $subQuery->where('guest_team_id', $this->id)->whereRaw('home_points_after_draw < guest_points_after_draw')
                     )

--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -132,45 +132,45 @@ class Team extends TranslateableModel implements HasMedia
         return $query
             ->where('id', $this->id)
             ->withSum([
-                'homeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'homeGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_legs')
             ->withSum([
-                'guestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'guestGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_legs')
             ->withSum([
-                'opponentHomeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'opponentHomeGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_legs')
             ->withSum([
-                'opponentGuestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'opponentGuestGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_legs')
             ->withSum([
-                'homeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'homeGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_games')
             ->withSum([
-                'guestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'guestGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_games')
             ->withSum([
-                'opponentGuestGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'opponentGuestGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'guest_points_games')
             ->withSum([
-                'opponentHomeGames' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
+                'opponentHomeGames' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
             ], 'home_points_games')
             ->withCount([
-                'games as total_number_of_encounters' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now),
-                'games as total_wins' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
+                'games as total_number_of_encounters' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now),
+                'games as total_wins' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now)
                     ->where(fn ($subQuery) => $subQuery->where(fn ($subQuery) => $subQuery->where('home_team_id', $this->id)->whereRaw('home_points_games > guest_points_games')
                     )->orWhere(fn ($subQuery) => $subQuery->where('guest_team_id', $this->id)->whereRaw('home_points_games < guest_points_games')
                     )
                     ),
-                'games as total_defeats' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
+                'games as total_defeats' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now)
                     ->where(fn ($subQuery) => $subQuery->where(fn ($subQuery) => $subQuery->where('home_team_id', $this->id)->whereRaw('home_points_games < guest_points_games')
                     )->orWhere(fn ($subQuery) => $subQuery->where('guest_team_id', $this->id)->whereRaw('home_points_games > guest_points_games')
                     )
                     ),
-                'games as total_draws' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
+                'games as total_draws' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now)
                     ->whereRaw('home_points_games = guest_points_games'),
 
-                'games as total_victory_after_defeats' => fn (Builder $query) => $query->activeMatches($gameSchedule, $now)
+                'games as total_victory_after_defeats' => fn (Builder|Game $query) => $query->activeMatches($gameSchedule, $now)
                     ->where(fn ($subQuery) => $subQuery->where(fn ($subQuery) => $subQuery->where('home_team_id', $this->id)->whereRaw('home_points_after_draw > guest_points_after_draw')
                     )->orWhere(fn ($subQuery) => $subQuery->where('guest_team_id', $this->id)->whereRaw('home_points_after_draw < guest_points_after_draw')
                     )

--- a/tests/Domain/Game/Actions/UpdateTotalTeamPointsActionTest.php
+++ b/tests/Domain/Game/Actions/UpdateTotalTeamPointsActionTest.php
@@ -188,6 +188,38 @@ dataset('entriesUpdateTotalTeamPointsAction', function () {
             ],
         ]),
     ];
+});
+
+dataset('entriesAreAotUpdatedWithUpdateTotalTeamPointsAction', function () {
+    yield 'no calculation for zero entries' => [
+        'fluent' => fn () => new Fluent([
+            'calculation_type_id' => 2,
+            'outward_game' => [
+                'home_points_legs' => 25,
+                'guest_points_legs' => 50,
+                'home_points_games' => 0,
+                'guest_points_games' => 0,
+                'has_an_overtime' => false,
+                'started_at' => now()->subHours(36),
+                'ended_at' => now()->subHours(34),
+            ],
+            'back_game' => [
+                'home_points_legs' => 50,
+                'guest_points_legs' => 25,
+                'home_points_games' => 0,
+                'guest_points_games' => 0,
+                'has_an_overtime' => false,
+                'started_at' => now()->subHours(30),
+                'ended_at' => now()->subHours(28),
+            ],
+            'home_assert_database_has' => [
+                'total_points' => 0,
+            ],
+            'guest_assert_database_has' => [
+                'total_points' => 0,
+            ],
+        ]),
+    ];
     yield 'no calculation for future games' => [
         'fluent' => fn () => new Fluent([
             'calculation_type_id' => 2,
@@ -214,6 +246,96 @@ dataset('entriesUpdateTotalTeamPointsAction', function () {
         ]),
     ];
 });
+
+it('does not updates the total points', function (Fluent $fluent) {
+    $federation = FederationFactory::new()->create(['calculation_type_id' => $fluent->calculation_type_id]);
+    $gameSchedule = GameScheduleFactory::new()
+        ->for($federation)
+        ->for(LeagueFactory::new()->for($federation))
+        ->create();
+
+    GameDayFactory::new()
+        ->for($gameSchedule)
+        ->create(
+            [
+                'started_at' => now()->subDays(2),
+                'ended_at' => now()->subDays(1),
+            ]
+        );
+
+    $homeTeam = TeamFactory::new()->create();
+    $homeTeam->gameSchedules()->save($gameSchedule);
+    $guestTeam = TeamFactory::new()->create();
+    $guestTeam->gameSchedules()->save($gameSchedule);
+
+    GameFactory::new()
+        ->for($gameSchedule)
+        ->for(GameDayFactory::new(
+            [
+                'started_at' => now()->subDays(2),
+                'ended_at' => now()->subDays(1),
+            ]
+        )->for($gameSchedule))
+        ->for($homeTeam, 'homeTeam')
+        ->for($guestTeam, 'guestTeam')
+        ->create($fluent->outward_game);
+
+    GameFactory::new()
+        ->for($gameSchedule)
+        ->for(GameDayFactory::new(
+            [
+                'started_at' => now()->subDays(2),
+                'ended_at' => now()->subDays(1),
+            ]
+        )->for($gameSchedule))
+        ->for($guestTeam, 'homeTeam')
+        ->for($homeTeam, 'guestTeam')
+        ->create($fluent->back_game);
+
+    $totalTeamPointHome = TotalTeamPointFactory::new()
+        ->for($gameSchedule)
+        ->for($homeTeam)
+        ->create();
+    $totalTeamPointDataHome = TotalTeamPointData::createFromTotalTeamPointWithRecalculation($totalTeamPointHome);
+
+    $totalTeamPointGuest = TotalTeamPointFactory::new()
+        ->for($gameSchedule)
+        ->for($guestTeam)
+        ->create();
+    $totalTeamPointDataGuest = TotalTeamPointData::createFromTotalTeamPointWithRecalculation($totalTeamPointGuest);
+
+    app(UpdateTotalTeamPointsAction::class)->execute($totalTeamPointHome, $totalTeamPointDataHome);
+    app(UpdateTotalTeamPointsAction::class)->execute($totalTeamPointGuest, $totalTeamPointDataGuest);
+
+    tap(
+        $totalTeamPointHome->refresh(),
+        function (TotalTeamPoint $totalTeamPointHome) use ($fluent) {
+            $this->assertDatabaseHas(
+                TotalTeamPoint::class,
+                array_merge(
+                    [
+                        'id' => $totalTeamPointHome->id,
+                    ],
+                    $fluent->home_assert_database_has
+                )
+            );
+        }
+    );
+    tap(
+        $totalTeamPointGuest->refresh(),
+        function (TotalTeamPoint $totalTeamPointGuest) use ($fluent) {
+            $this->assertDatabaseHas(
+                TotalTeamPoint::class,
+                array_merge(
+                    [
+                        'id' => $totalTeamPointGuest->id,
+                    ],
+                    $fluent->guest_assert_database_has
+                )
+            );
+        }
+    );
+})->with('entriesUpdateTotalTeamPointsAction');
 
 it('updates the total points', function (Fluent $fluent) {
     $federation = FederationFactory::new()->create(['calculation_type_id' => $fluent->calculation_type_id]);
@@ -303,4 +425,4 @@ it('updates the total points', function (Fluent $fluent) {
             );
         }
     );
-})->with('entriesUpdateTotalTeamPointsAction');
+})->with('entriesAreAotUpdatedWithUpdateTotalTeamPointsAction');


### PR DESCRIPTION
Title: Fix Phpstan errors in Team class

Description: This pull request addresses the Phpstan errors in the Team class. It introduces the `scopeActiveMatches` scope and extends the `scopeRecalculatePoints` method in the Team class.

Changes Made:

-   Added `scopeActiveMatches` to filter records that are not in the future and have points entered.
-   Extended `scopeRecalculatePoints` method to consider only records with entered points for calculations.

This update ensures that only relevant records are considered for calculations and that points are properly accounted for. It resolves the Phpstan errors and improves the accuracy of calculations in the Team class.