### PR TITLE
Make player's email field nullable in forms and update tests

### DIFF
--- a/src/Resources/PlayerResource.php
+++ b/src/Resources/PlayerResource.php
@@ -103,7 +103,7 @@ class PlayerResource extends TranslateableResource
                         TextInput::make('email')
                             ->label(Player::transAttribute('email'))
                             ->validationAttribute(Player::transAttribute('email'))
-                            ->required()
+                            ->nullable()
                             ->email()
                             ->unique(ignoreRecord: true),
 

--- a/tests/Application/Resources/PlayerResourceTest.php
+++ b/tests/Application/Resources/PlayerResourceTest.php
@@ -88,7 +88,6 @@ it('can validate input for player page', function () {
             'league_id' => 'required',
             'team_id' => 'required',
             'name' => 'required',
-            'email' => 'required',
         ]);
 });
 


### PR DESCRIPTION
This commit makes the player's email field nullable in the forms, removing the requirement for it to be a mandatory field. The tests have been updated accordingly to reflect this change.

Changes Made:
- Made the player's email field nullable in the forms.
- Updated tests to accommodate the changes in the email field.

By making the email field nullable, users are no longer required to provide an email address when submitting the form. This allows for more flexibility in the data entry process.