### PR TITLE
feat: Expand player forms for optional selection of player role

### DIFF
--- a/resources/lang/de/filament-model.php
+++ b/resources/lang/de/filament-model.php
@@ -63,6 +63,7 @@ return [
             'nickname' => 'Spitzname',
             'id_number' => 'Ausweisnummer',
             'team_id' => 'Team',
+            'player_role_id' => 'Rolle',
             'created_at' => 'Erstellt am',
             'updated_at' => 'Aktualisiert am',
             'deleted_at' => 'Gelöscht am',

--- a/resources/lang/en/filament-model.php
+++ b/resources/lang/en/filament-model.php
@@ -63,6 +63,7 @@ return [
             'nickname' => 'Nickname',
             'id_number' => 'Badge number',
             'team_id' => 'Team',
+            'player_role_id' => 'Role',
             'created_at' => 'Created at',
             'updated_at' => 'Updated at',
             'deleted_at' => 'Deleted at',

--- a/src/Domain/Player/Actions/UpdateOrCreatePlayerAction.php
+++ b/src/Domain/Player/Actions/UpdateOrCreatePlayerAction.php
@@ -17,6 +17,7 @@ class UpdateOrCreatePlayerAction
 
             $player->fill($playerData->toArray());
             $player->team_id = $playerData->team_id;
+            $player->player_role_id = $playerData->player_role_id;
 
             $player->save();
 

--- a/src/Domain/Player/DTO/PlayerData.php
+++ b/src/Domain/Player/DTO/PlayerData.php
@@ -9,6 +9,7 @@ class PlayerData extends Data
     public function __construct(
         public null|int $id,
         public int $team_id,
+        public null|int $player_role_id,
         public string $name,
         public string $slug,
         public null|string $email,

--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -15,6 +15,7 @@ use Spatie\Sluggable\SlugOptions;
 
 /**
  * @property int|null $team_id
+ * @property int|null $player_role_id
  * @property string $name
  * @property string $email
  * @property string|null $slug

--- a/src/Models/Player.php
+++ b/src/Models/Player.php
@@ -92,6 +92,11 @@ class Player extends TranslateableModel implements HasMedia
         );
     }
 
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(PlayerRole::class, 'player_role_id', 'id');
+    }
+
     public function gameSchedules(): BelongsToMany
     {
         return $this->belongsToMany(GameSchedule::class);

--- a/src/Resources/PlayerResource/SelectOptions/PlayerRoleSelect.php
+++ b/src/Resources/PlayerResource/SelectOptions/PlayerRoleSelect.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Maggomann\FilamentTournamentLeagueAdministration\Resources\PlayerResource\SelectOptions;
+
+use Illuminate\Support\Collection;
+use Maggomann\FilamentTournamentLeagueAdministration\Models\PlayerRole;
+use Maggomann\FilamentTournamentLeagueAdministration\Resources\FreeTournamentResource\SelectOptions\Traits\HasTranslatableKeyPrefix;
+
+class PlayerRoleSelect
+{
+    use HasTranslatableKeyPrefix;
+
+    public static function options(): Collection
+    {
+        return self::collection();
+    }
+
+    protected static function collection(): Collection
+    {
+        return once(function () {
+            return PlayerRole::all()->pluck('title_translation_key', 'id')
+                ->mapWithKeys(fn ($value, $key) => [$key => __(static::$translatableKeyPrefix."{$value}")]);
+        });
+    }
+
+    public static function translatedById(?int $id = null): ?string
+    {
+        return once(function () use ($id) {
+            if (blank($id)) {
+                return null;
+            }
+
+            return static::collection()->get($id);
+        });
+    }
+}

--- a/tests/Application/Resources/PlayerResourceTest.php
+++ b/tests/Application/Resources/PlayerResourceTest.php
@@ -8,6 +8,7 @@ use Maggomann\FilamentOnlyIconDisplay\Domain\Tables\Actions\DeleteAction;
 use Maggomann\FilamentTournamentLeagueAdministration\Domain\Player\Actions\UpdateOrCreatePlayerAction;
 use Maggomann\FilamentTournamentLeagueAdministration\Domain\Player\DTO\PlayerData;
 use Maggomann\FilamentTournamentLeagueAdministration\Models\Player;
+use Maggomann\FilamentTournamentLeagueAdministration\Models\PlayerRole;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\AddressesResource\RelationManagers\AddressesRelationManager;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\PlayerResource;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\PlayerResource\RelationManagers\TeamRelationManager;
@@ -51,12 +52,14 @@ it('can create a player', function () {
     $federation = FederationFactory::new()->create();
     $league = LeagueFactory::new()->for($federation)->create();
     $team = TeamFactory::new()->for($league)->create();
+    $randomPlayerRole = PlayerRole::inRandomOrder()->first();
 
     livewire(PlayerResource\Pages\CreatePlayer::class)
         ->fillForm([
             'federation_id' => $federation->id,
             'league_id' => $league->id,
             'team_id' => $team->id,
+            'player_role_id' => $randomPlayerRole->id,
             'name' => 'Example',
             'slug' => 'example',
             'email' => 'example@example.com',
@@ -66,6 +69,7 @@ it('can create a player', function () {
 
     $this->assertDatabaseHas(Player::class, [
         'team_id' => $team->id,
+        'player_role_id' => $randomPlayerRole->id,
         'name' => 'Example',
         'slug' => 'example',
         'email' => 'example@example.com',
@@ -78,6 +82,7 @@ it('can validate input for player page', function () {
             'federation_id' => null,
             'league_id' => null,
             'team_id' => null,
+            'player_role_id' => null,
             'name' => null,
             'slug' => 'example',
             'email' => null,
@@ -95,6 +100,7 @@ it('player create page should receive execute from UpdateOrCreatePlayerAction', 
     $federation = FederationFactory::new()->create();
     $league = LeagueFactory::new()->for($federation)->create();
     $team = TeamFactory::new()->for($league)->create();
+    $randomPlayerRole = PlayerRole::inRandomOrder()->first();
 
     $mock = $this->mock(UpdateOrCreatePlayerAction::class);
     $mock->shouldReceive('execute')
@@ -107,6 +113,7 @@ it('player create page should receive execute from UpdateOrCreatePlayerAction', 
         'federation_id' => $federation->id,
         'league_id' => $league->id,
         'team_id' => $team->id,
+        'player_role_id' => $randomPlayerRole->id,
         'name' => 'Example',
         'slug' => 'example',
         'email' => 'example@example.com',
@@ -118,6 +125,7 @@ it('can save a player', function () {
     $federation = FederationFactory::new()->create();
     $league = LeagueFactory::new()->for($federation)->create();
     $team = TeamFactory::new()->for($league)->create();
+    $randomPlayerRole = PlayerRole::inRandomOrder()->first();
 
     $player = PlayerFactory::new()
         ->withPlausibleBelongsToRelations()
@@ -130,6 +138,7 @@ it('can save a player', function () {
             'federation_id' => $federation->id,
             'league_id' => $league->id,
             'team_id' => $team->id,
+            'player_role_id' => $randomPlayerRole->id,
             'name' => 'Example Edit',
             'slug' => 'example-edit',
             'email' => 'example-edit@example.com',
@@ -145,6 +154,7 @@ it('can save a player', function () {
     $this->assertDatabaseHas(Player::class, [
         'id' => $player->id,
         'team_id' => $team->id,
+        'player_role_id' => $randomPlayerRole->id,
         'name' => 'Example Edit',
         'slug' => 'example-edit',
         'email' => 'example-edit@example.com',
@@ -155,6 +165,7 @@ it('player edit page should receive execute from UpdateOrCreateTeamAction', func
     $federation = FederationFactory::new()->create();
     $league = LeagueFactory::new()->for($federation)->create();
     $team = TeamFactory::new()->for($league)->create();
+    $randomPlayerRole = PlayerRole::inRandomOrder()->first();
 
     $player = PlayerFactory::new()
         ->withPlausibleBelongsToRelations()
@@ -172,6 +183,7 @@ it('player edit page should receive execute from UpdateOrCreateTeamAction', func
         'federation_id' => $federation->id,
         'league_id' => $league->id,
         'team_id' => $team->id,
+        'player_role_id' => $randomPlayerRole->id,
         'name' => 'Example',
         'slug' => 'example',
         'email' => 'example@example.com',

--- a/tests/Domain/Player/DTO/PlayerDataTest.php
+++ b/tests/Domain/Player/DTO/PlayerDataTest.php
@@ -7,6 +7,7 @@ beforeEach(function () {
     $this->validParams = [
         'id' => 1,
         'team_id' => 1,
+        'player_role_id' => 1,
         'name' => 'valid string',
         'slug' => 'valid string',
         'email' => 'valid string',
@@ -36,6 +37,7 @@ test('PlayerData throws an error when invalid data is submitted', function ($key
 })->with([
     ['id', []],
     ['team_id', null],
+    ['player_role_id', 'invalid string'],
     ['name', null],
     ['slug', null],
     ['email', []],


### PR DESCRIPTION
This pull request adds an enhancement to the player management feature by expanding the forms and tests to allow for optional selection of the player role. The existing column tournament_league_players.player_role_id was utilized for this purpose.

With this enhancement, users now have the flexibility to choose a player role when managing players, providing a more comprehensive and customizable experience.