### PR TITLE
feat: Expand team forms for optional address management

### DIFF
--- a/src/Models/Team.php
+++ b/src/Models/Team.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Korridor\LaravelHasManyMerged\HasManyMerged;
 use Korridor\LaravelHasManyMerged\HasManyMergedRelation;
+use Maggomann\Addressable\Traits\Addressable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Sluggable\HasSlug;
@@ -37,6 +38,7 @@ use Spatie\Sluggable\SlugOptions;
  */
 class Team extends TranslateableModel implements HasMedia
 {
+    use Addressable;
     use HasFactory;
     use HasManyMergedRelation;
     use HasSlug;

--- a/src/Resources/TeamResource.php
+++ b/src/Resources/TeamResource.php
@@ -27,6 +27,7 @@ use Maggomann\FilamentTournamentLeagueAdministration\Models\CalculationType;
 use Maggomann\FilamentTournamentLeagueAdministration\Models\Federation;
 use Maggomann\FilamentTournamentLeagueAdministration\Models\League;
 use Maggomann\FilamentTournamentLeagueAdministration\Models\Team;
+use Maggomann\FilamentTournamentLeagueAdministration\Resources\AddressesResource\RelationManagers\AddressesRelationManager;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\Forms\Components\CardUploadAndTimestamps;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\TeamResource\Pages;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\TeamResource\RelationManagers\PlayersRelationManager;
@@ -171,6 +172,7 @@ class TeamResource extends TranslateableResource
     {
         return [
             PlayersRelationManager::class,
+            AddressesRelationManager::class,
         ];
     }
 
@@ -185,7 +187,7 @@ class TeamResource extends TranslateableResource
 
     protected static function getGlobalSearchEloquentQuery(): Builder
     {
-        return parent::getGlobalSearchEloquentQuery()->with(['league.federation', 'players']);
+        return parent::getGlobalSearchEloquentQuery()->with(['league.federation', 'addresses', 'players']);
     }
 
     public static function getGlobalSearchResultDetails(Model $record): array

--- a/tests/Application/Resources/TeamResourceTest.php
+++ b/tests/Application/Resources/TeamResourceTest.php
@@ -8,6 +8,7 @@ use Maggomann\FilamentOnlyIconDisplay\Domain\Tables\Actions\DeleteAction;
 use Maggomann\FilamentTournamentLeagueAdministration\Domain\Team\Actions\UpdateOrCreateTeamAction;
 use Maggomann\FilamentTournamentLeagueAdministration\Domain\Team\DTO\TeamData;
 use Maggomann\FilamentTournamentLeagueAdministration\Models\Team;
+use Maggomann\FilamentTournamentLeagueAdministration\Resources\AddressesResource\RelationManagers\AddressesRelationManager;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\TeamResource;
 use Maggomann\FilamentTournamentLeagueAdministration\Resources\TeamResource\RelationManagers\PlayersRelationManager;
 use function Pest\Livewire\livewire;
@@ -39,6 +40,12 @@ it('can render all player relation managers', function () {
         'ownerRecord' => $team,
     ])
         ->assertSuccessful();
+
+    livewire(AddressesRelationManager::class, [
+        'ownerRecord' => $team,
+    ])
+        ->assertSuccessful()
+        ->assertCanNotSeeTableRecords($team->addresses);
 });
 
 it('can create a team', function () {


### PR DESCRIPTION
This pull request introduces an enhancement to the team administration feature by expanding the forms and tests to enable optional address management. Users now have the flexibility to manage addresses for teams, providing a more comprehensive and customizable experience.